### PR TITLE
:hourglass: Create a first draft for a logo (`svg`)

### DIFF
--- a/assets/logo-no-name.svg
+++ b/assets/logo-no-name.svg
@@ -1,0 +1,11 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:rgb(255,0,0);stop-opacity:1" />
+      <stop offset="50%" style="stop-color:rgb(255,165,0);stop-opacity:1" />
+      <stop offset="100%" style="stop-color:rgb(0,255,0);stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <path d="M 50,50 L 150,50 L 100,100 L 150,150 L 50,150 L 100,100 Z"
+        stroke="url(#grad1)" stroke-width="20" fill="none" stroke-linejoin="round"/>
+</svg>

--- a/assets/logo-with-name.svg
+++ b/assets/logo-with-name.svg
@@ -1,0 +1,12 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:rgb(255,0,0);stop-opacity:1" />
+      <stop offset="50%" style="stop-color:rgb(255,165,0);stop-opacity:1" />
+      <stop offset="100%" style="stop-color:rgb(0,255,0);stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <path d="M 50,50 L 150,50 L 100,100 L 150,150 L 50,150 L 100,100 Z"
+        stroke="url(#grad1)" stroke-width="20" fill="none" stroke-linejoin="round"/>
+  <text x="100" y="190" font-family="sans-serif" font-size="35" font-weight="bold" text-anchor="middle" fill="darkgreen">geol</text>
+</svg>


### PR DESCRIPTION
# :grey_question: About

We'll need to give a visual identity to `geol` which should : 

- Remember colors of the `product lifecycle
- Remember the hourglass
- Be simple to draw, par exemple in a terminal
- Stays very simple
- Easy to draw by hand
- Reminds `geol`
- Be easy to embed in a sqared logo design

Therefore I have drafted a first version


# :telescope: Perspectives

The main idea is in a near future to build an `about` output that may look like this

<img width="729" height="242" alt="image" src="https://github.com/user-attachments/assets/5365d2aa-bc47-4a95-a37a-f61cf1b03e20" />


or like this

<img width="702" height="279" alt="image" src="https://github.com/user-attachments/assets/96b093d3-2745-4c59-a997-d270f95b99b1" />
