### PR TITLE
:memo: Add an example for the "n" option to the extended sub-command

### DIFF
--- a/cmd/product/extended.go
+++ b/cmd/product/extended.go
@@ -24,7 +24,8 @@ func init() {
 var extendedCmd = &cobra.Command{
 	Use:     "extended",
 	Aliases: []string{"e"},
-	Example: `geol product extended golang k8s`,
+	Example: `geol product extended golang k8s
+geol product extended quarkus -n 15`,
 	Short:   "Display extended release information for specified products (latest 10 versions by default).",
 	Long:    `Retrieve and display detailed release data for one or more products, including cycle, release dates, support periods, and end-of-life information. By default, the latest 10 versions are shown for each product; use the --number flag to display the latest n versions instead. Results are formatted in a styled table for easy reading. Products must exist in the local cache or be available via the API.`,
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
# :grey_question: About

I saw that AI agents found it more easily to use examples. In the man page the `n` option is very easy to understand.