### PR TITLE
:bar_chart:  Add insights to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![GoDoc](https://godoc.org/github.com/opt-nc/geol?status.svg)](https://pkg.go.dev/github.com/opt-nc/geol)
 [![lint-workflow](https://github.com/opt-nc/geol/actions/workflows/golangci-lint.yml/badge.svg)](https://github.com/opt-nc/geol/actions/workflows/golangci-lint.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11239/badge)](https://www.bestpractices.dev/projects/11239)
+[![📊 OSS Insights](https://img.shields.io/badge/OSS%20Insights-%F0%9F%93%8A-blue)](https://ossinsight.io/analyze/opt-nc/geol#overview)
 
 # ❔ About
 


### PR DESCRIPTION
# :grey_question: About

I was looking for **extras and nice to use KPIs** and found this open alternative (and **no registration required**).... for example the [map of contributors](https://ossinsight.io/analyze/opt-nc/geol#people) : 


<img width="1126" height="829" alt="image" src="https://github.com/user-attachments/assets/5fa7c4d7-d9ae-4b43-a418-fbe4f9d76972" />

