### PR TITLE
fix: properly downsample styles and replace fatih/color with lipgloss

### DIFF
--- a/cmd/about.go
+++ b/cmd/about.go
@@ -1,14 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"runtime"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/phuslu/log"
 
 	"github.com/common-nighthawk/go-figure"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -30,9 +29,9 @@ var aboutCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Define colors using the company's hexadecimal codes
 		// #2E7D32 (vert)
-		titleColor := color.New(color.FgHiGreen, color.Bold, color.Attribute(38), color.Attribute(2))
-		sloganColor := color.New(color.Italic) // #FFFFFF (white) en italic
-		sectionColor := color.New(color.FgHiGreen, color.Bold, color.Attribute(38), color.Attribute(2))
+		titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.BrightGreen)
+		sloganStyle := lipgloss.NewStyle().Italic(true) // #FFFFFF (white) en italic
+		sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.BrightGreen)
 
 		// Generate ASCII art in yellow on blue background
 		myFigure := figure.NewFigure("geol", "starwars", true)
@@ -45,102 +44,102 @@ var aboutCmd = &cobra.Command{
 		}
 		for _, line := range asciiArtLines {
 			paddedLine := line + strings.Repeat(" ", maxLength-len(line))
-			if _, err := titleColor.Println(paddedLine); err != nil {
+			if _, err := lipgloss.Println(titleStyle.Render(paddedLine)); err != nil {
 				log.Error().Err(err).Msg("Error printing ASCII art line")
 			}
 		}
 
 		// Display the slogan in white and italic
-		if _, err := sloganColor.Println("⏳ Tech doesn’t last forever. Awareness does."); err != nil {
+		if _, err := lipgloss.Println(sloganStyle.Render("⏳ Tech doesn’t last forever. Awareness does.")); err != nil {
 			log.Error().Err(err).Msg("Error printing slogan")
 		}
 
 		// Display injected metadata
-		fmt.Println()
-		if _, err := sectionColor.Println("--- Build Info ---"); err != nil {
+		_, _ = lipgloss.Println()
+		if _, err := lipgloss.Println(sectionStyle.Render("--- Build Info ---")); err != nil {
 			log.Error().Err(err).Msg("Error printing build info section")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "GitVersion:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "GitVersion:"); err != nil {
 			log.Error().Err(err).Msg("Error printing GitVersion label")
 		}
-		if _, err := fmt.Println(Version); err != nil {
+		if _, err := lipgloss.Println(Version); err != nil {
 			log.Error().Err(err).Msg("Error printing GitVersion value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "Git Commit:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "Git Commit:"); err != nil {
 			log.Error().Err(err).Msg("Error printing Git Commit label")
 		}
-		if _, err := fmt.Println(Commit); err != nil {
+		if _, err := lipgloss.Println(Commit); err != nil {
 			log.Error().Err(err).Msg("Error printing Git Commit value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "BuildDate:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "BuildDate:"); err != nil {
 			log.Error().Err(err).Msg("Error printing BuildDate label")
 		}
-		if _, err := fmt.Println(Date); err != nil {
+		if _, err := lipgloss.Println(Date); err != nil {
 			log.Error().Err(err).Msg("Error printing BuildDate value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "BuiltBy:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "BuiltBy:"); err != nil {
 			log.Error().Err(err).Msg("Error printing BuiltBy label")
 		}
-		if _, err := fmt.Println(BuiltBy); err != nil {
+		if _, err := lipgloss.Println(BuiltBy); err != nil {
 			log.Error().Err(err).Msg("Error printing BuiltBy value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "GoVersion:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "GoVersion:"); err != nil {
 			log.Error().Err(err).Msg("Error printing GoVersion label")
 		}
-		if _, err := fmt.Println(GoVersion); err != nil {
+		if _, err := lipgloss.Println(GoVersion); err != nil {
 			log.Error().Err(err).Msg("Error printing GoVersion value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "Compiler:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "Compiler:"); err != nil {
 			log.Error().Err(err).Msg("Error printing Compiler label")
 		}
-		if _, err := fmt.Println(runtime.Compiler); err != nil {
+		if _, err := lipgloss.Println(runtime.Compiler); err != nil {
 			log.Error().Err(err).Msg("Error printing Compiler value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "Platform:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "Platform:"); err != nil {
 			log.Error().Err(err).Msg("Error printing Platform label")
 		}
-		if _, err := fmt.Printf("%s/%s\n", runtime.GOOS, runtime.GOARCH); err != nil {
+		if _, err := lipgloss.Printf("%s/%s\n", runtime.GOOS, runtime.GOARCH); err != nil {
 			log.Error().Err(err).Msg("Error printing Platform value")
 		}
 
 		// Affichage des ressources
-		fmt.Println()
-		if _, err := sectionColor.Println("--- Ressources ---"); err != nil {
+		_, _ = lipgloss.Println()
+		if _, err := lipgloss.Println(sectionStyle.Render("--- Ressources ---")); err != nil {
 			log.Error().Err(err).Msg("Error printing resources section")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "Licence:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "Licence:"); err != nil {
 			log.Error().Err(err).Msg("Error printing Licence label")
 		}
-		if _, err := fmt.Println("Apache-2.0"); err != nil {
+		if _, err := lipgloss.Println("Apache-2.0"); err != nil {
 			log.Error().Err(err).Msg("Error printing Licence value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "Code:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "Code:"); err != nil {
 			log.Error().Err(err).Msg("Error printing Code label")
 		}
-		if _, err := fmt.Println("https://github.com/opt-nc/geol"); err != nil {
+		if _, err := lipgloss.Println("https://github.com/opt-nc/geol"); err != nil {
 			log.Error().Err(err).Msg("Error printing Code value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "Roadmap:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "Roadmap:"); err != nil {
 			log.Error().Err(err).Msg("Error printing Roadmap label")
 		}
-		if _, err := fmt.Println("https://github.com/orgs/opt-nc/projects/28"); err != nil {
+		if _, err := lipgloss.Println("https://github.com/orgs/opt-nc/projects/28"); err != nil {
 			log.Error().Err(err).Msg("Error printing Roadmap value")
 		}
 
-		if _, err := fmt.Printf("%-20s ", "API:"); err != nil {
+		if _, err := lipgloss.Printf("%-20s ", "API:"); err != nil {
 			log.Error().Err(err).Msg("Error printing API label")
 		}
-		if _, err := fmt.Println("https://endoflife.date"); err != nil {
+		if _, err := lipgloss.Println("https://endoflife.date"); err != nil {
 			log.Error().Err(err).Msg("Error printing API value")
 		}
 	},

--- a/cmd/category.go
+++ b/cmd/category.go
@@ -9,7 +9,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
-	"github.com/fatih/color"
 	"github.com/opt-nc/geol/utilities"
 	"github.com/spf13/cobra"
 )
@@ -85,21 +84,19 @@ geol category cloud`,
 			os.Exit(1)
 		}
 
-		categoryColor := color.New(color.Bold)
-		productColor := color.New(color.Bold)
 		treeRoot := tree.Root(".")
-		categoryNode := tree.New().Root(categoryColor.Sprint(category))
+		categoryNode := tree.New().Root(boldStyle.Render(category))
 		for _, prod := range apiResp.Result {
-			categoryNode.Child(productColor.Sprint(prod.Name))
+			categoryNode.Child(boldStyle.Render(prod.Name))
 		}
 		treeRoot.Child(categoryNode)
-		if _, err := fmt.Fprintln(os.Stdout, treeRoot.String()); err != nil {
+		if _, err := lipgloss.Println(treeRoot.String()); err != nil {
 			fmt.Printf("Error printing tree for category '%s': %v\n", category, err)
 			os.Exit(1)
 		}
 		nbProducts := len(apiResp.Result)
 		nbProductsStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
-		if _, err := fmt.Fprintf(os.Stdout, "\n%s products listed for category '%s'\n", nbProductsStyle.Render(fmt.Sprintf("%d", nbProducts)), category); err != nil {
+		if _, err := lipgloss.Printf("\n%s products listed for category '%s'\n", nbProductsStyle.Render(fmt.Sprintf("%d", nbProducts)), category); err != nil {
 			fmt.Printf("Error printing product count for category '%s': %v\n", category, err)
 			os.Exit(1)
 		}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -332,8 +332,8 @@ geol check --file stack.yaml`,
 			Bold(true).Foreground(lipgloss.Color("#FFFF88")).
 			Background(lipgloss.Color("#5F5FFF")).
 			Render("# " + config.AppName)
-		fmt.Println(styledTitle)
-		fmt.Println(tableStr)
+		_, _ = lipgloss.Println(styledTitle)
+		_, _ = lipgloss.Println(tableStr)
 		if errorOut && strict {
 			os.Exit(1)
 		}

--- a/cmd/list/items/categories.go
+++ b/cmd/list/items/categories.go
@@ -1,13 +1,11 @@
 package items
 
 import (
-	"fmt"
 	"os"
 	"sort"
 	"strconv"
 
 	"charm.land/lipgloss/v2"
-	"github.com/fatih/color"
 	"github.com/opt-nc/geol/utilities"
 	"github.com/phuslu/log"
 	"github.com/spf13/cobra"
@@ -41,11 +39,10 @@ geol l c`,
 			names = append(names, name)
 		}
 		sort.Strings(names)
-		categoryColor := color.New(color.Bold)
 
 		plusStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2")).Render("+")
 		for _, name := range names {
-			if _, err := fmt.Fprintf(os.Stdout, "%s %s\n", plusStyle, categoryColor.Sprint(name)); err != nil {
+			if _, err := lipgloss.Printf("%s %s\n", plusStyle, boldStyle.Render(name)); err != nil {
 				log.Error().Err(err).Msg("Error writing category name to stdout")
 				os.Exit(1)
 			}
@@ -53,7 +50,7 @@ geol l c`,
 
 		nbCategories := strconv.Itoa(len(names))
 		nbCategoriesStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
-		if _, err := fmt.Fprintf(os.Stdout, "\n%s categories listed\n", nbCategoriesStyle.Render(nbCategories)); err != nil {
+		if _, err := lipgloss.Printf("\n%s categories listed\n", nbCategoriesStyle.Render(nbCategories)); err != nil {
 			log.Error().Err(err).Msg("Error writing category count to stdout")
 			os.Exit(1)
 		}

--- a/cmd/list/items/products.go
+++ b/cmd/list/items/products.go
@@ -8,11 +8,12 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
-	"github.com/fatih/color"
 	"github.com/opt-nc/geol/utilities"
 	"github.com/phuslu/log"
 	"github.com/spf13/cobra"
 )
+
+var boldStyle = lipgloss.NewStyle().Bold(true)
 
 func init() {
 	ProductsCmd.Flags().BoolP("tree", "t", false, "List all products including aliases in a tree structure.")
@@ -49,7 +50,6 @@ geol l p -t`,
 			names = append(names, name)
 		}
 		sort.Strings(names)
-		productColor := color.New(color.Bold)
 
 		if treeFlag {
 			// Print the list of products with aliases in a tree structure using lipgloss
@@ -61,7 +61,7 @@ geol l p -t`,
 					aliases = aliases[1:]
 				}
 				sort.Strings(aliases)
-				t := tree.New().Root(productColor.Sprint(name))
+				t := tree.New().Root(boldStyle.Render(name))
 				for _, item := range aliases {
 					t.Child(item)
 				}
@@ -75,7 +75,7 @@ geol l p -t`,
 			// Print the list of products with a green '+ product' prefix using lipgloss
 			plusStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2")).Render("+")
 			for _, name := range names {
-				if _, err := fmt.Fprintf(os.Stdout, "%s %s\n", plusStyle, productColor.Sprint(name)); err != nil {
+				if _, err := lipgloss.Printf("%s %s\n", plusStyle, boldStyle.Render(name)); err != nil {
 					log.Error().Err(err).Msg("Error writing product name to stdout")
 					os.Exit(1)
 				}
@@ -84,7 +84,7 @@ geol l p -t`,
 
 		nbProducts := strconv.Itoa(len(names))
 		nbProductsStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
-		if _, err := fmt.Fprintf(os.Stdout, "\n%s products listed\n", nbProductsStyle.Render(nbProducts)); err != nil {
+		if _, err := lipgloss.Printf("\n%s products listed\n", nbProductsStyle.Render(nbProducts)); err != nil {
 			log.Error().Err(err).Msg("Error writing product count to stdout")
 			os.Exit(1)
 		}

--- a/cmd/list/items/tags.go
+++ b/cmd/list/items/tags.go
@@ -1,13 +1,11 @@
 package items
 
 import (
-	"fmt"
 	"os"
 	"sort"
 	"strconv"
 
 	"charm.land/lipgloss/v2"
-	"github.com/fatih/color"
 	"github.com/opt-nc/geol/utilities"
 	"github.com/phuslu/log"
 	"github.com/spf13/cobra"
@@ -41,11 +39,10 @@ geol l t`,
 			names = append(names, name)
 		}
 		sort.Strings(names)
-		tagColor := color.New(color.Bold)
 
 		plusStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2")).Render("+")
 		for _, name := range names {
-			if _, err := fmt.Fprintf(os.Stdout, "%s %s\n", plusStyle, tagColor.Sprint(name)); err != nil {
+			if _, err := lipgloss.Printf("%s %s\n", plusStyle, boldStyle.Render(name)); err != nil {
 				log.Error().Err(err).Msg("Error writing tag name to stdout")
 				os.Exit(1)
 			}
@@ -53,7 +50,7 @@ geol l t`,
 
 		nbTags := strconv.Itoa(len(names))
 		nbTagsStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
-		if _, err := fmt.Fprintf(os.Stdout, "\n%s tags listed\n", nbTagsStyle.Render(nbTags)); err != nil {
+		if _, err := lipgloss.Printf("\n%s tags listed\n", nbTagsStyle.Render(nbTags)); err != nil {
 			log.Error().Err(err).Msg("Error writing tag count to stdout")
 			os.Exit(1)
 		}

--- a/cmd/product/describe.go
+++ b/cmd/product/describe.go
@@ -130,7 +130,7 @@ var describeCmd = &cobra.Command{
 			Foreground(lipgloss.Color("#FFFF88")).
 			Background(lipgloss.Color("#5F5FFF")).
 			Render("# " + mainName)
-		if _, err := os.Stdout.Write([]byte(styledTitle)); err != nil {
+		if _, err := lipgloss.Print(styledTitle); err != nil {
 			log.Error().Err(err).Msg("Error writing styled title")
 			os.Exit(1)
 		}
@@ -141,7 +141,7 @@ var describeCmd = &cobra.Command{
 			log.Error().Err(err).Msg("Error rendering markdown")
 			os.Exit(1)
 		}
-		if _, err := os.Stdout.Write([]byte(out)); err != nil {
+		if _, err := lipgloss.Print(out); err != nil {
 			log.Error().Err(err).Msg("Error writing rendered markdown")
 			os.Exit(1)
 		}

--- a/cmd/product/extended.go
+++ b/cmd/product/extended.go
@@ -142,14 +142,14 @@ geol product extended quarkus > quarkus-eol.md`,
 			Bold(true).Foreground(lipgloss.Color("#FFFF88")).
 			Background(lipgloss.Color("#5F5FFF")).
 			Render("# Products")
-		fmt.Println(styledTitle)
+		_, _ = lipgloss.Println(styledTitle)
 
 		// Lipgloss table rendering with lipgloss/table
 		for _, prod := range allProducts {
 			styledTitle := lipgloss.NewStyle().
 				Bold(true).Foreground(lipgloss.Color("#00AFF8")).
 				Render("\n## " + prod.Name + "\n")
-			fmt.Println(styledTitle)
+			_, _ = lipgloss.Println(styledTitle)
 
 			// Determine which columns have at least one value
 			showName, showReleaseDate, showLatestName, showLatestDate, showEoasFrom, showEolFrom := false, false, false, false, false, false
@@ -195,7 +195,7 @@ geol product extended quarkus > quarkus-eol.md`,
 			}
 
 			if len(columns) == 0 {
-				fmt.Println(lipgloss.NewStyle().Italic(true).Foreground(lipgloss.Color("244")).Render("No release data available."))
+				_, _ = lipgloss.Println(lipgloss.NewStyle().Italic(true).Foreground(lipgloss.Color("244")).Render("No release data available."))
 				continue
 			}
 
@@ -299,7 +299,7 @@ geol product extended quarkus > quarkus-eol.md`,
 				return lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Align(lipgloss.Left).Padding(0, padding)
 			})
 			renderedTable := t.Render()
-			fmt.Println(renderedTable)
+			_, _ = lipgloss.Println(renderedTable)
 			// Always show a summary line below the table
 			tableLines := strings.Split(renderedTable, "\n")
 			maxLen := 0
@@ -309,7 +309,7 @@ geol product extended quarkus > quarkus-eol.md`,
 				}
 			}
 			summary := fmt.Sprintf("%d rows (%d shown)", len(prod.Releases), displayCount)
-			fmt.Printf("%s\n", summary)
+			_, _ = lipgloss.Println(summary)
 		}
 	},
 }

--- a/cmd/product/product.go
+++ b/cmd/product/product.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/glamour/v2"
 	"github.com/opt-nc/geol/utilities"
 	"github.com/phuslu/log"
@@ -150,7 +151,8 @@ geol product describe nodejs`,
 		if err != nil {
 			fmt.Print(buf.String()) // raw fallback
 		} else {
-			fmt.Print(out)
+			// Use lipgloss print to handle NoTTY and color downsampling.
+			_, _ = lipgloss.Print(out)
 		}
 	},
 }

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -12,10 +12,11 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
-	"github.com/fatih/color"
 	"github.com/opt-nc/geol/utilities"
 	"github.com/spf13/cobra"
 )
+
+var boldStyle = lipgloss.NewStyle().Bold(true)
 
 // tagCmd represents the tag command
 var tagCmd = &cobra.Command{
@@ -88,21 +89,19 @@ geol tag canonical`,
 			os.Exit(1)
 		}
 
-		tagColor := color.New(color.Bold)
-		productColor := color.New(color.Bold)
 		treeRoot := tree.Root(".")
-		tagNode := tree.New().Root(tagColor.Sprint(tag))
+		tagNode := tree.New().Root(boldStyle.Render(tag))
 		for _, prod := range apiResp.Result {
-			tagNode.Child(productColor.Sprint(prod.Name))
+			tagNode.Child(boldStyle.Render(prod.Name))
 		}
 		treeRoot.Child(tagNode)
-		if _, err := fmt.Fprintln(os.Stdout, treeRoot.String()); err != nil {
+		if _, err := lipgloss.Println(treeRoot.String()); err != nil {
 			fmt.Printf("Error printing tree for tag '%s': %v\n", tag, err)
 			os.Exit(1)
 		}
 		nbProducts := len(apiResp.Result)
 		nbProductsStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
-		if _, err := fmt.Fprintf(os.Stdout, "\n%s products listed for tag '%s'\n", nbProductsStyle.Render(fmt.Sprintf("%d", nbProducts)), tag); err != nil {
+		if _, err := lipgloss.Printf("\n%s products listed for tag '%s'\n", nbProductsStyle.Render(fmt.Sprintf("%d", nbProducts)), tag); err != nil {
 			fmt.Printf("Error printing product count for tag '%s': %v\n", tag, err)
 			os.Exit(1)
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/charmbracelet/glamour/v2 v2.0.0-20251106195642-800eb8175930
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
-	github.com/fatih/color v1.18.0
 	github.com/phuslu/log v1.0.120
 	github.com/spf13/cobra v1.10.1
 	golang.org/x/term v0.37.0
@@ -33,8 +32,6 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
-github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -57,10 +55,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
-github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
@@ -101,7 +95,6 @@ golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
 golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=


### PR DESCRIPTION
This commit ensures that all styled outputs are correctly downsampled when the terminal does not support colors or styles like when redirecting output. It also replaces the usage of the fatih/color package with lipgloss for consistent styling across the application and reduces dependencies.

Fixes: https://github.com/opt-nc/geol/issues/189
Fixes: https://github.com/opt-nc/geol/issues/184