### PR TITLE
fix: Bad geol version in yaml check example

### DIFF
--- a/cmd/templates/checkTemplate.yaml
+++ b/cmd/templates/checkTemplate.yaml
@@ -1,4 +1,4 @@
-geolVersion: "1"
+geolVersion: "2"
 # cuelang file : https://github.com/opt-nc/geol/blob/main/geol_stack.cue
 app_name: MySuperApp
 


### PR DESCRIPTION
# :question:  About

This PR fixes the fact that since [`v2.0.0`](https://github.com/opt-nc/geol/releases/tag/v2.0.0) we should put the new major version in the `yaml`.