### PR TITLE
:repeat: eat your own dog food > `.geol.yaml` configuration file for `geol` itself :sweat_smile: 

### DIFF
--- a/.geol.yaml
+++ b/.geol.yaml
@@ -1,0 +1,8 @@
+geolVersion: "2"
+# cuelang file : https://github.com/opt-nc/geol/blob/main/geol_stack.cue
+app_name: geol stack
+
+stack:
+  - name: Go
+    version: "1.25"
+    id_eol: go


### PR DESCRIPTION

<img width="864" height="247" alt="image" src="https://github.com/user-attachments/assets/bdd2e2d5-455e-4734-a11e-72336e415f97" />


# :grey_question: About

I wanted to known about `geol` stack easily, for now it only relies on `go`.... and it may a good way to keep track of Go runtime cf

- https://github.com/opt-nc/geol/issues/127


# :bookmark_tabs: Related topics

- https://github.com/opt-nc/geol/issues/16
