### PR TITLE
fix: Cheatsheet - Fix `sed` command when branch has a "/" in its name

### DIFF
--- a/assets/cheatsheet/Taskfile.yml
+++ b/assets/cheatsheet/Taskfile.yml
@@ -32,7 +32,7 @@ tasks:
 
     cmds:
       - mkdir -p {{.OUTPUT_DIR}}
-      - sed -e "s/__GEOL_COMMIT__/{{.COMMIT}}/g" -e "s/__GEOL_BRANCH__/{{.BRANCH}}/g" -e "s/__GEOL_VERSION__/{{.VERSION}}/g" {{.BASENAME}}.tex > {{.OUTPUT_DIR}}/.{{.BASENAME}}_tmp.tex
+      - sed -e "s|__GEOL_COMMIT__|{{.COMMIT}}|g" -e "s|__GEOL_BRANCH__|{{.BRANCH}}|g" -e "s|__GEOL_VERSION__|{{.VERSION}}|g" {{.BASENAME}}.tex > {{.OUTPUT_DIR}}/.{{.BASENAME}}_tmp.tex
       - xelatex -interaction=batchmode -jobname={{.BASENAME}} -output-directory={{.OUTPUT_DIR}} {{.OUTPUT_DIR}}/.{{.BASENAME}}_tmp.tex
       # - rm {{.OUTPUT_DIR}}/.{{.BASENAME}}_tmp.tex
       - |


### PR DESCRIPTION
# :question:  About

The cheatsheet build file does actually not support `/` in the branch name.... which causes the task to fail for exammple on `doc/site` branch.


:point_right: This PR fixes that