### PR TITLE
feat: Minor cheatsheet look & feel improvements

### DIFF
--- a/assets/cheatsheet/cheatsheet_geol.tex
+++ b/assets/cheatsheet/cheatsheet_geol.tex
@@ -89,10 +89,12 @@
     \begin{center}
         \begin{terminaltitle}
             \centering
+            \vspace{0.125cm}
             \geolLogo[scale=0.02, baseline=-20pt] \\
             {\textcolor{logoGreen}{\texttt{geol}}} \\
             {\color{white}\href{https://github.com/opt-nc/geol}{opt-nc/geol}} \\
             {\color{white}\large \textit{"\textcolor{logoGreen}{\texttt{geol}}, because software End of Life management is too serious to be boring"}}
+            \vspace{0.125cm}
         \end{terminaltitle}
     \end{center}
 }
@@ -140,7 +142,6 @@
 \begin{geolbox}
 \begin{geolitemize}
   \item \cmd{brew install -{}-cask opt-nc/homebrew-tap/geol}
-  \item \cmd{go install github.com/opt-nc/geol@latest}
   \item \cmd{geol help}
   \item \cmd{geol about}
 \end{geolitemize}


### PR DESCRIPTION
# :grey_question:  About

This PR enhances the following points (spotted on the printed version weeks ago) : 

- Removed the `go install` which seems a too technical approach for this cheatsheet... hence makes us save space 
- Bad vertical space margins for the top part of the cheatsheet : le logo was too  near from the top page
<img width="1068" height="540" alt="image" src="https://github.com/user-attachments/assets/ebf7cec2-8bc6-489c-b97f-eab94d21ee6b" />
