### PR TITLE
Add always-latest option to Go stack configuration

### DIFF
--- a/.geol.yaml
+++ b/.geol.yaml
@@ -6,3 +6,4 @@ stack:
   - name: Go
     version: "1.25"
     id_eol: go
+    always-latest: true


### PR DESCRIPTION
# :grey_question: About

Be sure to alwauys use the latest Go version :nerd_face: 