### PR TITLE
🦕  Revise Data Engineering documentation for clarity

### DIFF
--- a/_site/docs/tutorial-extras/dataengineering.md
+++ b/_site/docs/tutorial-extras/dataengineering.md
@@ -3,44 +3,66 @@ sidebar_position: 2
 ---
 
  # Data Engineering with `geol`
-Data Engineering with `geol explains how to collect, normalize, and analyze product metadata (versions, release dates, end-of-life) for downstream analytics. It covers ingestion, storage, querying and exporting workflows (CSV, DuckDB) to build repeatable ETL pipelines and reports.
 
-### Requirements
+`geol` offers features that make it possible and easy for datascientists, dataengineers, or devops engineers
+to analyze EOL and products at scale comfortably with data tools, hence making it possible to produce
+`csv`, `duckdb` or any other portable format.
 
-- `duckdb` — install with Homebrew using the following command:
-```bash
-brew install duckdb
-```
-See https://duckdb.org/ for more installation options and details.
+With these features, it is very easy to load these data in any `ETL` or reporting tools.
 
 ## Export to DuckDB
 
-You can export product information to a DuckDB database using the following command:
+`geol` natively supports `duckdb` export: you can export product information to a DuckDB database using the following command:
+
 ```bash
 geol export
 file geol.duckdb
 ```
+
 This command produces the file `geol.duckdb` containing the exported product information.
+
+You are now ready to play with the `duckdb` file.
+
+## Requirement
+
+To play with the `duckdb` file, you need to have `duckdb` setup and ready (recommanded install option below):
+
+```bash
+brew install duckdb
+```
+
+See [DuckDB Installation](https://duckdb.org/install/?platform=linux&environment=cli) for more installation options.
+
 
 ## Basic DuckDB examples
 
 Show DuckDB help:
+
 ```shell
 duckdb -help
 ```
-Run a single SQL command (The `tags` table can be replaced with `products`, `categories`, ...) without opening the interactive CLI:
+
+Run a single SQL command (The `tags` table can be replaced with `products`, `categories`, ...) without
+opening the interactive CLI:
+
 ```bash
 duckdb geol.duckdb -c "select * from tags;"
 ```
+
 Open the database in the DuckDB CLI (opens `geol.duckdb`):
+
 ```shell
 duckdb geol.duckdb
 ```
+
 Inside the DuckDB CLI you can run SQL. For example, list tags:
+
 ```shell
 from tags;
 ```
+
 Count the number of products:
+
 ```shell
 select count(*) from products;
 ```


### PR DESCRIPTION
Updated the Data Engineering section to clarify the features of `geol` for data analysis and provided additional details on DuckDB installation and usage.

Saw this while shooting demo https://youtu.be/G_x2Aven5Yg
cf
- https://github.com/opt-nc/geol/pull/264