### PR TITLE
:shield:  Upgrade to `13.6-slim` (huge security improvement)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM debian:13.5-slim
+FROM debian:13.6-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/geol /usr/local/bin/geol


### PR DESCRIPTION
# :grey_question: About

Regarding the [latest announce](https://9to5linux.com/debian-13-6-trixie-released-with-124-bug-fixes-and-120-security-updates) : 

<img width="1307" height="990" alt="image" src="https://github.com/user-attachments/assets/de6b0bbd-5335-4b81-a9d1-1b649408c0ce" />
