### PR TITLE
:arrow_up:  Update Go version from 1.26 to 1.27

### DIFF
--- a/.geol.yaml
+++ b/.geol.yaml
@@ -4,6 +4,6 @@ app_name: geol stack
 
 stack:
   - name: Go
-    version: "1.26"
+    version: "1.27"
     id_eol: go
     always-latest: true

--- a/.github/workflows/geol-action.yml
+++ b/.github/workflows/geol-action.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Run Geol Check stack status # will fail if the .geol file is not present, you can use the geol check init command to create one
         run: |
-          geol check ##--strict Waiting for codeql to upgrade to latest go version
+          geol check --strict

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/opt-nc/geol/v2
 
-go 1.26.7
+go 1.27.0
 
 require (
-	charm.land/bubbles/v2 v2.1.1
+	charm.land/bubbles/v2 v2.2.0
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6
@@ -28,8 +28,8 @@ require (
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be // indirect
 	github.com/charmbracelet/x/ansi v0.11.8 // indirect
-	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260816001655-68d539dca504 // indirect
-	github.com/charmbracelet/x/exp/slice v0.0.0-20260816001655-68d539dca504 // indirect
+	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260823001701-96af6d2cb5f6 // indirect
+	github.com/charmbracelet/x/exp/slice v0.0.0-20260823001701-96af6d2cb5f6 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be // indirect
 	github.com/charmbracelet/x/ansi v0.11.8 // indirect
-	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260823001701-96af6d2cb5f6 // indirect
-	github.com/charmbracelet/x/exp/slice v0.0.0-20260823001701-96af6d2cb5f6 // indirect
+	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260830003929-9f48cc723c1c // indirect
+	github.com/charmbracelet/x/exp/slice v0.0.0-20260830003929-9f48cc723c1c // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,12 +38,12 @@ github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be h1:qEvkJ
 github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
 github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
 github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
-github.com/charmbracelet/x/exp/charmtone v0.0.0-20260823001701-96af6d2cb5f6 h1:hjsO4Xtwmx1PynpHM4fQQxqnlWHjONrWhoPAfBoM5I0=
-github.com/charmbracelet/x/exp/charmtone v0.0.0-20260823001701-96af6d2cb5f6/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20260830003929-9f48cc723c1c h1:E69qrHmdmcvcJWnYp6IjdUYLe14r317QGI+M/VyeeGM=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20260830003929-9f48cc723c1c/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260823001701-96af6d2cb5f6 h1:je2x9scjVLOqRwO5JbFyRzyG5aCLg64DSOvd463cm04=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260823001701-96af6d2cb5f6/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260830003929-9f48cc723c1c h1:NrexJt03stF3jc99mH9MwkYCc8rKMmLmOgk16D4blTo=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260830003929-9f48cc723c1c/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
-charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
+charm.land/bubbles/v2 v2.2.0 h1:9GEMewcejrNtVIxZ9Y2wSsWJamsWNsXa8MpMLnH4yI4=
+charm.land/bubbles/v2 v2.2.0/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
 charm.land/bubbletea/v2 v2.0.9 h1:DpJCMWKgzQK8SJv4zbKKFHAI10ymWy/evClPFk0k0f8=
 charm.land/bubbletea/v2 v2.0.9/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/glamour/v2 v2.0.1 h1:xl+r00A4aJWU0z8fgwKd9fQQ4rsphqGUzuEiXZP5n+c=
@@ -38,12 +38,12 @@ github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be h1:qEvkJ
 github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
 github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
 github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
-github.com/charmbracelet/x/exp/charmtone v0.0.0-20260816001655-68d539dca504 h1:vXmc9iOQFML+9lTrD8Bzvysnpl5I0MjGqPe9B4j6AHM=
-github.com/charmbracelet/x/exp/charmtone v0.0.0-20260816001655-68d539dca504/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20260823001701-96af6d2cb5f6 h1:hjsO4Xtwmx1PynpHM4fQQxqnlWHjONrWhoPAfBoM5I0=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20260823001701-96af6d2cb5f6/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260816001655-68d539dca504 h1:Z0hBPQ9hslsfpFRRdMn+4cjnb3LK6FQH58hQkXrXv0A=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260816001655-68d539dca504/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260823001701-96af6d2cb5f6 h1:je2x9scjVLOqRwO5JbFyRzyG5aCLg64DSOvd463cm04=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260823001701-96af6d2cb5f6/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=


### PR DESCRIPTION
# :grey_question: About

This PR is just a trigger to start the whole go upgrade to the `1.27`

<img width="747" height="445" alt="image" src="https://github.com/user-attachments/assets/cf516ce3-f651-4f9b-8daa-df3c626215c1" />


# :bulb: More about 1.27

Cf [tweet](https://x.com/linuxiac/status/2090197579690582519) and [releaseNote](https://linuxiac.com/go-1-27-released-with-generic-methods-json-v2-and-faster-memory-allocation/) (For more details, [see the official announcement](https://go.dev/doc/go1.27) or the [release notes](https://go.dev/doc/go1.27).)

<img width="587" height="663" alt="image" src="https://github.com/user-attachments/assets/9e9f6521-8f3b-42fa-ab64-e1561904f9af" />

Maybe the mst intersing for us could be : 

> At the same time, the standard library receives one of its largest changes with the introduction of encoding/json/v2 and encoding/json/jsontext. The former is a substantial revision of Go’s existing JSON package, while jsontext provides lower-level syntactic JSON processing through encoders and decoders operating on tokens and values.
> 
> JSON v2 adopts stricter defaults, rejecting invalid UTF-8 strings and duplicate object member names. Importantly, existing applications are not forced onto the new API. The familiar encoding/json package remains supported but is now backed by the v2 implementation while preserving its existing marshaling and unmarshaling behavior.